### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 cli2msml
 ======
 
-[![Downloads](https://pypip.in/download/cli2msml/badge.svg)](https://pypi.python.org/pypi/cli2msml/)
-[![Latest Version](https://pypip.in/version/cli2msml/badge.svg)](https://pypi.python.org/pypi/cli2msml/)
-[![Supported Python versions](https://pypip.in/py_versions/cli2msml/badge.svg)](https://pypi.python.org/pypi/cli2msml/)
-[![Development Status](https://pypip.in/status/cli2msml/badge.svg)](https://pypi.python.org/pypi/cli2msml/)
-[![License](https://pypip.in/license/cli2msml/badge.svg)](https://pypi.python.org/pypi/cli2msml/)
+[![Downloads](https://img.shields.io/pypi/dm/cli2msml.svg)](https://pypi.python.org/pypi/cli2msml/)
+[![Latest Version](https://img.shields.io/pypi/v/cli2msml.svg)](https://pypi.python.org/pypi/cli2msml/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/cli2msml.svg)](https://pypi.python.org/pypi/cli2msml/)
+[![Development Status](https://img.shields.io/pypi/status/cli2msml.svg)](https://pypi.python.org/pypi/cli2msml/)
+[![License](https://img.shields.io/pypi/l/cli2msml.svg)](https://pypi.python.org/pypi/cli2msml/)
 
 [![Build Status](https://travis-ci.org/CognitionGuidedSurgery/cli2msml.svg?branch=circle)](https://travis-ci.org/CognitionGuidedSurgery/cli2msml)
 [![Code Health](https://landscape.io/github/CognitionGuidedSurgery/cli2msml/master/landscape.svg)](https://landscape.io/github/CognitionGuidedSurgery/cli2msml/master)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cli2msml))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cli2msml`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.